### PR TITLE
CIをいいかんじに

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
 
       # install QEMU
       - name: Install QEMU (Linux)
-        run: sudo apt update && sudo apt install qemu-system-x86
+        run: sudo apt-get update && sudo apt-get install qemu-system-x86
       - name: Run `cargo test`
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,7 +91,8 @@ jobs:
           toolchain: nightly
           components: clippy, rust-src
           override: true
-      - name: Run `cargo clippy`
-        uses: actions-rs/cargo@v1
+      - name: Run clippy-check
+        uses: actions-rs/clippy-check@v1
         with:
-          command: clippy
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, update-rust-ci ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ main, update-rust-ci ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 


### PR DESCRIPTION
- スクリプト内なら`apt`より`apt-get`
- [clippy-check](https://github.com/actions-rs/clippy-check) はいいぞ